### PR TITLE
add connection between packer and ansible

### DIFF
--- a/packer/ansible.sh
+++ b/packer/ansible.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -eo pipefail
+
+cd ..
+bin/ansible-playbook "$@"

--- a/packer/image.pkr.hcl
+++ b/packer/image.pkr.hcl
@@ -9,4 +9,8 @@ source "openstack" "gateway" {
 
 build {
   sources = ["source.openstack.gateway"]
+  provisioner "ansible" {
+    command       = "./ansible.sh"
+    playbook_file = "../ansible/playbooks/gateway.yml"
+  }
 }


### PR DESCRIPTION
# Short description

This PR adds a connection between Packer and Ansible. Now we can create an image that is provisioned by an ansible playbook.

# Changes

Add the ansible provisionner in the packer file.
Create the command file (ansible.sh) that allows packer to initialize the ansible environment for the creation of the image.

# Tests

This code was tested with a dummy playbook, and the test passed.
