### PR TITLE
Fix Kamailio cloud init

### DIFF
--- a/terraform/kamailio.cloud-init.sh
+++ b/terraform/kamailio.cloud-init.sh
@@ -22,3 +22,5 @@ sed -i -E "s/alias=\"[^\"]*\"/alias=\"$KAMAILIO_IP\"/" /etc/kamailio/kamailio.cf
 
 sed -i -E "s/SIP_DOMAIN=[^\"]*/SIP_DOMAIN=$KAMAILIO_IP/" /etc/kamailio/kamctlrc
 sed -i -E "s/DBACCESSHOST=[^\"]*/DBACCESSHOST=$KAMAILIO_IP/" /etc/kamailio/kamctlrc
+
+systemctl restart kamailio.service


### PR DESCRIPTION
# Short description

It fixes the Kamailio cloud init

# Changes

Restarted service to apply changes made to the configuration files during the cloud init

# Tests

Ran Terraform apply