### PR TITLE
Coturn cloud init

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -7,6 +7,7 @@ export TF_VAR_coturn_name \
     TF_VAR_coturn_image \
     TF_VAR_coturn_flavor \
     TF_VAR_coturn_network \
+    TF_VAR_coturn_domain_name \
     TF_VAR_coturn_port \
     TF_VAR_coturn_stun_user \
     TF_VAR_coturn_stun_pass \

--- a/env.d/terraform.dist
+++ b/env.d/terraform.dist
@@ -1,16 +1,17 @@
 # Coturn configuration variables
 TF_VAR_coturn_name=coturn
-TF_VAR_coturn_image="Debian 11"
+TF_VAR_coturn_image="Coturn"
 TF_VAR_coturn_flavor=s1-2
 TF_VAR_coturn_network=Ext-Net
 
+TF_VAR_coturn_domain_name="coturn.local"
 TF_VAR_coturn_port=3478
 TF_VAR_coturn_stun_user=coturn
 TF_VAR_coturn_stun_pass=
 
 # Kamailio configuration variables
 TF_VAR_kamailio_name=kamailio
-TF_VAR_kamailio_image="Debian 11"
+TF_VAR_kamailio_image="Kamailio"
 TF_VAR_kamailio_flavor=s1-2
 TF_VAR_kamailio_network=Ext-Net
 

--- a/terraform/coturn.cloud-init.sh
+++ b/terraform/coturn.cloud-init.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+COTURN_IP=$(hostname -I | grep -o -E "([0-9]{1,3}\.){3}[0-9]{1,3}")
+COTURN_DOMAIN=${coturn_domain}
+COTURN_PORT=${coturn_port}
+STUN_USER=${stun_user}
+STUN_PASS=${stun_pass}
+
+sed -i -E "s/listening-port=[0-9]{1,5}/listening-port=$COTURN_PORT/" /etc/turnserver.conf
+sed -i -E "s/external-ip=([0-9]{1,3}\.){3}[0-9]{1,3}/external-ip=$COTURN_IP/" /etc/turnserver.conf
+sed -i -E "s/realm=.*$/realm=$COTURN_DOMAIN/" /etc/turnserver.conf
+sed -i -E "s/user=[^:]*:[^\"]*$/user=$STUN_USER:$STUN_PASS/" /etc/turnserver.conf
+
+systemctl restart coturn.service

--- a/terraform/coturn.tf
+++ b/terraform/coturn.tf
@@ -19,6 +19,11 @@ variable "coturn_network" {
   description = "The name of the network of the Coturn instance."
 }
 
+variable "coturn_domain_name" {
+  type        = string
+  description = "The domain name for the Coturn instance"
+}
+
 variable "coturn_port" {
   type        = number
   description = "The port on which the Coturn server shall be contacted"
@@ -39,6 +44,12 @@ resource "openstack_compute_instance_v2" "coturn" {
   image_name  = var.coturn_image
   flavor_name = var.coturn_flavor
   key_pair    = var.key_pair
+  user_data = templatefile("${path.module}/coturn.cloud-init.sh", {
+    coturn_port   = var.coturn_port,
+    coturn_domain = var.coturn_domain_name,
+    stun_user     = var.coturn_stun_user,
+    stun_pass     = var.coturn_stun_pass,
+  })
 
   network {
     name = var.coturn_network


### PR DESCRIPTION
# Short description

It adds a cloud init script for the Coturn server

# Changes

Added coturn cloud init to configure it automatically on instanciation
Changed default images in Terraform environment variables

# Tests

Ran Terraform apply on our Openstack testing cluster