### PR TITLE
Add metadatas and scaler in Terraform

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -16,6 +16,10 @@ export TF_VAR_coturn_name \
     TF_VAR_kamailio_flavor \
     TF_VAR_kamailio_network \
     TF_VAR_kamailio_sip_secret \
+    TF_VAR_scaler_name \
+    TF_VAR_scaler_image \
+    TF_VAR_scaler_flavor \
+    TF_VAR_scaler_network \
     TF_VAR_key_pair \
     OS_AUTH_URL \
     OS_USERNAME \

--- a/env.d/terraform.dist
+++ b/env.d/terraform.dist
@@ -17,6 +17,12 @@ TF_VAR_kamailio_network=Ext-Net
 
 TF_VAR_kamailio_sip_secret=
 
+# Scaler configuration variables
+TF_VAR_scaler_name=scaler
+TF_VAR_scaler_image=
+TF_VAR_scaler_flavor=s1-2
+TF_VAR_scaler_network=Ext-Net
+
 # Administration configuration
 TF_VAR_key_pair=
 

--- a/terraform/coturn.tf
+++ b/terraform/coturn.tf
@@ -54,4 +54,8 @@ resource "openstack_compute_instance_v2" "coturn" {
   network {
     name = var.coturn_network
   }
+
+  metadata = {
+    "sipmediagw.group" = "coturn"
+  }
 }

--- a/terraform/kamailio.tf
+++ b/terraform/kamailio.tf
@@ -40,4 +40,8 @@ resource "openstack_compute_instance_v2" "kamailio" {
   network {
     name = var.kamailio_network
   }
+
+  metadata = {
+    "sipmediagw.group" = "kamailio"
+  }
 }

--- a/terraform/scaler.tf
+++ b/terraform/scaler.tf
@@ -28,4 +28,8 @@ resource "openstack_compute_instance_v2" "scaler" {
   network {
     name = var.scaler_network
   }
+
+  metadata = {
+    "sipmediagw.group" = "scaler"
+  }
 }

--- a/terraform/scaler.tf
+++ b/terraform/scaler.tf
@@ -1,0 +1,31 @@
+variable "scaler_name" {
+  type        = string
+  description = "The name of the scaler instance."
+  default     = "scaler"
+}
+
+variable "scaler_image" {
+  type        = string
+  description = "The name of the image of the scaler instance."
+}
+
+variable "scaler_flavor" {
+  type        = string
+  description = "The name of the flavor of the scaler instance."
+}
+
+variable "scaler_network" {
+  type        = string
+  description = "The name of the network of the scaler instance."
+}
+
+resource "openstack_compute_instance_v2" "scaler" {
+  name        = var.scaler_name
+  image_name  = var.scaler_image
+  flavor_name = var.scaler_flavor
+  key_pair    = var.key_pair
+
+  network {
+    name = var.scaler_network
+  }
+}


### PR DESCRIPTION
# Short description

It adds metadata to be used by the [scaling module](https://github.com/Renater/SimpleScaleVM) and a basic configuration for its deployment in Terraform

# Changes

Added the scaler module in Terraform configuration to prepare its future deployment
Added metadata to every instance deployed by Terraform

# Tests

Ran Terraform apply and checked on Horizon