### PR TITLE
Fix displayname containing space characters and gateway being stuck on login page

### DIFF
--- a/ansible/roles/gateway-launcher/defaults/main.yml
+++ b/ansible/roles/gateway-launcher/defaults/main.yml
@@ -12,7 +12,7 @@ stun_password: "1234"
 
 # Gateway configuration
 gateway_image_name: renater/sipmediagw
-gateway_image_tag: 1.0.0
+gateway_image_tag: 1.1.1
 gateway_cpu_cores_per_gateway: 2.5
 
 # Option to start gateways at the end of the execution

--- a/ansible/roles/kamailio/files/request_gw.py
+++ b/ansible/roles/kamailio/files/request_gw.py
@@ -74,8 +74,8 @@ class RequestGw:
                     gwUri = gwRes[1]
                     Logger.LM_ERR('Returned Gateway: %s\n' % gwUri)
                     msg.rewrite_ruri("sip:%s@%s" % (gwUri, self.serverAddr))
-                    displayNameWRoom = "{}-{}".format(room,displayName.replace('"',''))
-                    KSR.uac.uac_replace_from(displayNameWRoom, "");
+                    displayNameWRoom = '"%s-%s%s"' % (str(len(room)), room, displayName.replace('"',''))
+                    KSR.uac.uac_replace_from(displayNameWRoom, "")
                     Logger.LM_ERR('########## SIP request, method = %s, RURI = %s, From = %s\n' % (msg.Method, msg.RURI, msg.getHeader('from')))
 
         return 1


### PR DESCRIPTION
This PR aims at integrating  the last fix related to display name customization in Kamailio, coming from https://github.com/Renater/SIPMediaGW/blob/main/test/kamailio/request_gw.py
