### PR TITLE
add coturn server check

### DIFF
--- a/ansible/roles/coturn/files/webserver.py
+++ b/ansible/roles/coturn/files/webserver.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import re
+import web
+import json
+import subprocess
+import os
+
+class Status:
+    def GET(self, args=None):
+        coturnStatus=0
+        readyToDelete=True
+        status=os.system("systemctl is-active --quiet coturn")
+        if status==0 :
+            coturnStatus=1
+            readyToDelete=False
+        return json.dumps({"coturnStatus":coturnStatus,"readyToDelete":readyToDelete})
+
+urls = ("/status", "Status")
+app = web.application(urls, globals())
+
+if __name__ == "__main__":
+    app.run()

--- a/ansible/roles/coturn/handlers/main.yml
+++ b/ansible/roles/coturn/handlers/main.yml
@@ -4,3 +4,13 @@
   ansible.builtin.systemd:
     name: coturn
     state: restarted
+
+- name: Start the webserver
+  ansible.builtin.command: sudo -u {{ webserver_user }} pm2 start {{ webserver_directory }}/pm2-ecosystem.yml
+
+- name: Save the pm2 configuration
+  ansible.builtin.command: sudo -u {{ webserver_user }} pm2 save
+
+- name: Configure pm2 automatic start at boot
+  become: true
+  ansible.builtin.command: pm2 startup systemd -u {{ webserver_user }} --hp {{ webserver_directory }}

--- a/ansible/roles/coturn/meta/main.yml
+++ b/ansible/roles/coturn/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 galaxy_info:
-  role_name: Coturn
+  role_name: coturn
   author: Renater
   description: An Ansible role to deploy and configure a Coturn server
   company: Renater

--- a/ansible/roles/coturn/tasks/main.yml
+++ b/ansible/roles/coturn/tasks/main.yml
@@ -1,4 +1,23 @@
 ---
+- name: Create the Coturn user
+  become: true
+  ansible.builtin.user:
+    name: "{{ webserver_user }}"
+    home: "{{ webserver_directory }}"
+
+- name: Install pip
+  become: true
+  ansible.builtin.apt:
+    name: python3-pip
+    state: present
+    update_cache: true
+
+- name: Install pip requirements for the webserver
+  become: true
+  ansible.builtin.pip:
+    name: web.py=={{ webpy_package_version }}
+    state: present
+
 - name: Install Coturn
   become: true
   ansible.builtin.apt:
@@ -18,4 +37,28 @@
   ansible.builtin.template:
     src: turnserver.conf.j2
     dest: /etc/turnserver.conf
+    owner: turnserver
+    group: turnserver
+    mode: 0600
   notify: Restart Coturn
+
+- name: Copy the webserver deployment file
+  become: true
+  ansible.builtin.copy:
+    src: webserver.py
+    dest: "{{ webserver_directory }}/webserver.py"
+    owner: "{{ webserver_user }}"
+    group: "{{ webserver_user }}"
+    mode: 0600
+
+- name: Copy the webserver deployment template
+  become: true
+  ansible.builtin.template:
+    src: pm2-ecosystem.yml
+    dest: "{{ webserver_directory }}/pm2-ecosystem.yml"
+    owner: "{{ webserver_user }}"
+    group: "{{ webserver_user }}"
+    mode: 0600
+
+- name: Start the webserver with pm2
+  ansible.builtin.include_tasks: pm2.yml

--- a/ansible/roles/coturn/tasks/pm2.yml
+++ b/ansible/roles/coturn/tasks/pm2.yml
@@ -1,0 +1,39 @@
+---
+- name: Install Node.js and npm
+  become: true
+  ansible.builtin.apt:
+    name:
+      - nodejs
+      - npm
+    state: present
+    update_cache: true
+
+- name: Install pm2 with npm
+  become: true
+  community.general.npm:
+    name: pm2
+    version: "{{ pm2_package_version }}"
+    global: true
+    state: present
+
+- name: Check if the webserver is alive
+  become: true
+  ansible.builtin.command:
+    cmd: sudo -u {{ webserver_user }} pm2 pid webserver
+    chdir: "{{ webserver_directory }}"
+  check_mode: false
+  register: pm2_status
+  changed_when: |-
+    pm2_status.stdout == "" or
+    pm2_status.stdout == "0" or
+    pm2_status.stdout | length > 30
+  notify:
+    - Start the webserver
+    - Save the pm2 configuration
+
+- name: Check if pm2 automatic start is configured
+  ansible.builtin.stat:
+    path: /etc/systemd/system/pm2-{{ webserver_user }}.service
+  register: pm2_automatic_start_status
+  changed_when: not pm2_automatic_start_status.stat.exists
+  notify: Configure pm2 automatic start at boot

--- a/ansible/roles/coturn/templates/pm2-ecosystem.yml
+++ b/ansible/roles/coturn/templates/pm2-ecosystem.yml
@@ -1,0 +1,7 @@
+apps:
+  - script: webserver.py
+    name:  webserver
+    cwd: "{{ webserver_directory }}"
+    interpreter: /usr/bin/python3
+    instances: 1
+    exec_mode: fork

--- a/ansible/roles/coturn/vars/main.yml
+++ b/ansible/roles/coturn/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# Gateway constant variables
+webserver_user: coturn
+webserver_directory: /var/coturn
+
+# Package versions
+webpy_package_version: 0.62
+pm2_package_version: 5.2.0


### PR DESCRIPTION

# Short description
It sets up a web server that allows us to perform checks on the Coturn instance
# Changes

the Coturn Ansible playbook and Ansible role are adjusted accordingly.

# Tests

These changes were deployed and tested.
