### PR TITLE
Added variables for scaler configuration in Terraform

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -15,6 +15,7 @@ export OS_AUTH_URL \
     OS_IDENTITY_API_VERSION \
     TF_VAR_key_pair \
     TF_VAR_gateway_webrtc_domain \
+    TF_VAR_gateway_host_capacity \
     TF_VAR_coturn_name \
     TF_VAR_coturn_image \
     TF_VAR_coturn_flavor \
@@ -33,6 +34,7 @@ export OS_AUTH_URL \
     TF_VAR_scaler_image \
     TF_VAR_scaler_flavor \
     TF_VAR_scaler_network \
+    TF_VAR_scaler_available_gateways_minimum \
     TF_VAR_scaler_os_auth_url \
     TF_VAR_scaler_os_username \
     TF_VAR_scaler_os_password \

--- a/env.d/terraform.dist
+++ b/env.d/terraform.dist
@@ -20,6 +20,7 @@ TF_VAR_key_pair=
 
 # Gateway configuration
 TF_VAR_gateway_webrtc_domain="meet.jit.si"
+TF_VAR_gateway_host_capacity=1
 
 # Coturn configuration variables
 TF_VAR_coturn_name=coturn
@@ -47,6 +48,7 @@ TF_VAR_scaler_image="Scaler"
 TF_VAR_scaler_flavor=s1-2
 TF_VAR_scaler_network=Ext-Net
 
+TF_VAR_scaler_available_gateways_minimum=3
 TF_VAR_scaler_os_auth_url=${OS_AUTH_URL}
 TF_VAR_scaler_os_username=${OS_USERNAME}
 TF_VAR_scaler_os_password=${OS_PASSWORD}

--- a/terraform/gateway-host.tf
+++ b/terraform/gateway-host.tf
@@ -2,3 +2,8 @@ variable "gateway_webrtc_domain" {
   type        = string
   description = "The Web RTC domain that the gateways connect to."
 }
+
+variable "gateway_host_capacity" {
+  type        = number
+  description = "The number of gateways per gateway host."
+}

--- a/terraform/scaler.cloud-init.sh
+++ b/terraform/scaler.cloud-init.sh
@@ -2,6 +2,8 @@
 
 cd /var/scaler
 
+REPLICA_CAPACITY=${replica_capacity}
+REPLICA_MIN_AVAILABLE_RESOURCES=${replica_min_available_resources}
 OS_AUTH_URL=${os_auth_url}
 OS_USERNAME=${os_username}
 OS_PASSWORD=${os_password}
@@ -28,6 +30,8 @@ KAMAILIO_IP=${kamailio_ip}
 SIP_SECRET=${sip_secret}
 WEBRTC_DOMAIN=${webrtc_domain}
 
+sed -i -E "s/^REPLICA_CAPACITY=[0-9]*$/REPLICA_CAPACITY=$REPLICA_CAPACITY/" .env
+sed -i -E "s/^REPLICA_MIN_AVAILABLE_RESOURCES=[0-9]*$/REPLICA_MIN_AVAILABLE_RESOURCES=$REPLICA_MIN_AVAILABLE_RESOURCES/" .env
 sed -i -E "s/^OS_AUTH_URL=.*$/OS_AUTH_URL=$OS_AUTH_URL/" .env
 sed -i -E "s/^OS_USERNAME=.*$/OS_USERNAME=$OS_USERNAME/" .env
 sed -i -E "s/^OS_PASSWORD=.*$/OS_PASSWORD=$OS_PASSWORD/" .env

--- a/terraform/scaler.tf
+++ b/terraform/scaler.tf
@@ -19,6 +19,11 @@ variable "scaler_network" {
   description = "The name of the network of the scaler instance."
 }
 
+variable "scaler_available_gateways_minimum" {
+  type        = number
+  description = "The minimum number of available gateways at any time."
+}
+
 variable "scaler_os_auth_url" {
   type        = string
   description = "The URL of the Openstack endpoint."
@@ -110,30 +115,32 @@ resource "openstack_compute_instance_v2" "scaler" {
   flavor_name = var.scaler_flavor
   key_pair    = var.key_pair
   user_data = templatefile("${path.module}/scaler.cloud-init.sh", {
-    os_auth_url              = var.scaler_os_auth_url
-    os_username              = var.scaler_os_username
-    os_password              = var.scaler_os_password
-    os_region_name           = var.scaler_os_region_name
-    os_project_domain_id     = var.scaler_os_project_domain_id
-    os_user_domain_name      = var.scaler_os_user_domain_name
-    os_project_id            = var.scaler_os_project_id
-    os_project_name          = var.scaler_os_project_name
-    os_interface             = var.scaler_os_interface
-    os_identity_api_version  = var.scaler_os_identity_api_version
-    openstack_flavor         = var.scaler_openstack_flavor
-    openstack_image          = var.scaler_openstack_image
-    openstack_ip_version     = var.scaler_openstack_ip_version
-    openstack_network        = var.scaler_openstack_network
-    openstack_metadata_key   = var.scaler_openstack_metadata_key
-    openstack_metadata_value = var.scaler_openstack_metadata_value
-    openstack_keypair        = var.scaler_openstack_keypair
-    coturn_ip                = openstack_compute_instance_v2.coturn.access_ip_v4
-    coturn_port              = var.coturn_port
-    stun_user                = var.coturn_stun_user
-    stun_pass                = var.coturn_stun_pass
-    kamailio_ip              = openstack_compute_instance_v2.kamailio.access_ip_v4
-    sip_secret               = var.kamailio_sip_secret
-    webrtc_domain            = var.gateway_webrtc_domain
+    replica_capacity                = var.gateway_host_capacity
+    replica_min_available_resources = var.scaler_available_gateways_minimum
+    os_auth_url                     = var.scaler_os_auth_url
+    os_username                     = var.scaler_os_username
+    os_password                     = var.scaler_os_password
+    os_region_name                  = var.scaler_os_region_name
+    os_project_domain_id            = var.scaler_os_project_domain_id
+    os_user_domain_name             = var.scaler_os_user_domain_name
+    os_project_id                   = var.scaler_os_project_id
+    os_project_name                 = var.scaler_os_project_name
+    os_interface                    = var.scaler_os_interface
+    os_identity_api_version         = var.scaler_os_identity_api_version
+    openstack_flavor                = var.scaler_openstack_flavor
+    openstack_image                 = var.scaler_openstack_image
+    openstack_ip_version            = var.scaler_openstack_ip_version
+    openstack_network               = var.scaler_openstack_network
+    openstack_metadata_key          = var.scaler_openstack_metadata_key
+    openstack_metadata_value        = var.scaler_openstack_metadata_value
+    openstack_keypair               = var.scaler_openstack_keypair
+    coturn_ip                       = openstack_compute_instance_v2.coturn.access_ip_v4
+    coturn_port                     = var.coturn_port
+    stun_user                       = var.coturn_stun_user
+    stun_pass                       = var.coturn_stun_pass
+    kamailio_ip                     = openstack_compute_instance_v2.kamailio.access_ip_v4
+    sip_secret                      = var.kamailio_sip_secret
+    webrtc_domain                   = var.gateway_webrtc_domain
   })
 
   network {


### PR DESCRIPTION
# Short description

It allows the user to change the scaler configuration without rebuilding the Packer image

# Changes

Added 2 variables to allow a more flexible configuration of the scaler without having to rebuild the Packer image


# Tests

Deployed the stack with different values
