### PR TITLE
Add status check

### DIFF
--- a/ansible/playbooks/coturn.yml
+++ b/ansible/playbooks/coturn.yml
@@ -7,8 +7,6 @@
 - name: Set up the webserver for the status check
   hosts: all
   vars:
-    webserver_user: webserver
-    webserver_directory: /var/webserver
     service_name: coturn
   roles:
     - status-checker

--- a/ansible/playbooks/coturn.yml
+++ b/ansible/playbooks/coturn.yml
@@ -3,3 +3,12 @@
   hosts: all
   roles:
     - coturn
+
+- name: Set up the webserver for the status check
+  hosts: all
+  vars:
+    webserver_user: webserver
+    webserver_directory: /var/webserver
+    service_name: coturn
+  roles:
+    - status-checker

--- a/ansible/playbooks/kamailio.yml
+++ b/ansible/playbooks/kamailio.yml
@@ -3,3 +3,12 @@
   hosts: all
   roles:
     - kamailio
+
+- name: Set up the webserver for the status check
+  hosts: all
+  vars:
+    webserver_user: webserver
+    webserver_directory: /var/webserver
+    service_name: kamailio
+  roles:
+    - status-checker

--- a/ansible/playbooks/kamailio.yml
+++ b/ansible/playbooks/kamailio.yml
@@ -7,8 +7,6 @@
 - name: Set up the webserver for the status check
   hosts: all
   vars:
-    webserver_user: webserver
-    webserver_directory: /var/webserver
     service_name: kamailio
   roles:
     - status-checker

--- a/ansible/roles/status-checker/README.md
+++ b/ansible/roles/status-checker/README.md
@@ -17,6 +17,8 @@ To use this role in a playbook you can add
 
 ```yaml
 - hosts: all
+  vars:
+    service_name: ssh
   roles:
     - status-checker
 ```

--- a/ansible/roles/status-checker/README.md
+++ b/ansible/roles/status-checker/README.md
@@ -5,11 +5,11 @@ This role allows us to provision a webserver that provides a status check for a 
 ## Variables
 
 The variables defines in `defaults/main.yml` are to be overwritten by real values :
-* `webserver_user`: The user used to set up the webserver .
-* `webserver_directory`: The working directory for the webserver.
-* `service_name`: The service on which the status check is to be performed .
+* `webserver_user`: the user used to set up the webserver.
+* `webserver_directory`: the working directory for the webserver.
+* `service_name`: the service on which the status check is to be performed.
 
-The variables defined in `vars/main.yml` are defining a few package versions .
+The variables defined in `vars/main.yml` are defining a few package versions.
 
 ## Example Playbook
 

--- a/ansible/roles/status-checker/README.md
+++ b/ansible/roles/status-checker/README.md
@@ -4,7 +4,7 @@ This role allows us to provision a webserver that provides a status check for a 
 
 ## Variables
 
-The variables defined in `defaults/main.yml` can be overwritten by real values :
+The variables defined in `defaults/main.yml` can be overwritten by real values:
 * `webserver_user`: the user used to set up the webserver.
 * `webserver_directory`: the working directory for the webserver.
 * `service_name`: the service on which the status check is to be performed.

--- a/ansible/roles/status-checker/README.md
+++ b/ansible/roles/status-checker/README.md
@@ -1,0 +1,22 @@
+# Status-checker
+
+This role allows us to provision a webserver that provides a status check for a given service.
+
+## Variables
+
+The variables defines in `defaults/main.yml` are to be overwritten by real values :
+* `webserver_user`: The user used to set up the webserver .
+* `webserver_directory`: The working directory for the webserver.
+* `service_name`: The service on which the status check is to be performed .
+
+The variables defined in `vars/main.yml` are defining a few package versions .
+
+## Example Playbook
+
+To use this role in a playbook you can add
+
+```yaml
+- hosts: all
+  roles:
+    - status-checker
+```

--- a/ansible/roles/status-checker/README.md
+++ b/ansible/roles/status-checker/README.md
@@ -4,7 +4,7 @@ This role allows us to provision a webserver that provides a status check for a 
 
 ## Variables
 
-The variables defines in `defaults/main.yml` are to be overwritten by real values :
+The variables defined in `defaults/main.yml` can be overwritten by real values :
 * `webserver_user`: the user used to set up the webserver.
 * `webserver_directory`: the working directory for the webserver.
 * `service_name`: the service on which the status check is to be performed.

--- a/ansible/roles/status-checker/defaults/main.yml
+++ b/ansible/roles/status-checker/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+webserver_user: user
+webserver_directory: /var/user
+service_name: service

--- a/ansible/roles/status-checker/defaults/main.yml
+++ b/ansible/roles/status-checker/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-webserver_user: user
-webserver_directory: /var/user
+webserver_user: checker
+webserver_directory: /var/checker
 service_name: service

--- a/ansible/roles/status-checker/handlers/main.yml
+++ b/ansible/roles/status-checker/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Start the webserver
+  ansible.builtin.command: sudo -u {{ webserver_user }} pm2 start {{ webserver_directory }}/pm2-ecosystem.yml
+
+- name: Save the pm2 configuration
+  ansible.builtin.command: sudo -u {{ webserver_user }} pm2 save
+
+- name: Configure pm2 automatic start at boot
+  become: true
+  ansible.builtin.command: pm2 startup systemd -u {{ webserver_user }} --hp {{ webserver_directory }}

--- a/ansible/roles/status-checker/meta/main.yml
+++ b/ansible/roles/status-checker/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: status-checker
+  author: Renater
+  description: An Ansible role to deploy and configure a webserver to perform a status check on a givern service .
+  company: Renater
+
+  license: license (Apache-2.0)
+
+  min_ansible_version: "2.7"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bullseye
+
+  galaxy_tags:
+    - status
+
+dependencies: []

--- a/ansible/roles/status-checker/meta/main.yml
+++ b/ansible/roles/status-checker/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: status-checker
   author: Renater
-  description: An Ansible role to deploy and configure a webserver to perform a status check on a givern service .
+  description: An Ansible role to deploy and configure a webserver to perform a status check on a given service .
   company: Renater
 
   license: license (Apache-2.0)

--- a/ansible/roles/status-checker/meta/main.yml
+++ b/ansible/roles/status-checker/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   role_name: status-checker
   author: Renater
-  description: An Ansible role to deploy and configure a webserver to perform a status check on a given service .
+  description: An Ansible role to deploy and configure a webserver to perform a status check on a given service.
   company: Renater
 
   license: license (Apache-2.0)

--- a/ansible/roles/status-checker/tasks/main.yml
+++ b/ansible/roles/status-checker/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: Create the webserver user
+  become: true
+  ansible.builtin.user:
+    name: "{{ webserver_user }}"
+    home: "{{ webserver_directory }}"
+
+- name: Install pip
+  become: true
+  ansible.builtin.apt:
+    name: python3-pip
+    state: present
+    update_cache: true
+
+- name: Install pip requirements for the webserver
+  become: true
+  ansible.builtin.pip:
+    name: web.py=={{ webpy_package_version }}
+    state: present
+
+- name: Copy the webserver deployment templates
+  become: true
+  ansible.builtin.template:
+    src: "{{ webserver_deployement_template }}.j2"
+    dest: "{{ webserver_directory }}/{{ webserver_deployement_template }}"
+    owner: "{{ webserver_user }}"
+    group: "{{ webserver_user }}"
+    mode: 0600
+  loop:
+    - webserver.py
+    - pm2-ecosystem.yml
+  loop_control:
+    loop_var: webserver_deployement_template
+
+
+- name: Start the webserver with pm2
+  ansible.builtin.include_tasks: pm2.yml

--- a/ansible/roles/status-checker/tasks/main.yml
+++ b/ansible/roles/status-checker/tasks/main.yml
@@ -32,6 +32,5 @@
   loop_control:
     loop_var: webserver_deployement_template
 
-
 - name: Start the webserver with pm2
   ansible.builtin.include_tasks: pm2.yml

--- a/ansible/roles/status-checker/tasks/pm2.yml
+++ b/ansible/roles/status-checker/tasks/pm2.yml
@@ -1,0 +1,39 @@
+---
+- name: Install Node.js and npm
+  become: true
+  ansible.builtin.apt:
+    name:
+      - nodejs
+      - npm
+    state: present
+    update_cache: true
+
+- name: Install pm2 with npm
+  become: true
+  community.general.npm:
+    name: pm2
+    version: "{{ pm2_package_version }}"
+    global: true
+    state: present
+
+- name: Check if the webserver is alive
+  become: true
+  ansible.builtin.command:
+    cmd: sudo -u {{ webserver_user }} pm2 pid webserver
+    chdir: "{{ webserver_directory }}"
+  check_mode: false
+  register: pm2_status
+  changed_when: |-
+    pm2_status.stdout == "" or
+    pm2_status.stdout == "0" or
+    pm2_status.stdout | length > 30
+  notify:
+    - Start the webserver
+    - Save the pm2 configuration
+
+- name: Check if pm2 automatic start is configured
+  ansible.builtin.stat:
+    path: /etc/systemd/system/pm2-{{ webserver_user }}.service
+  register: pm2_automatic_start_status
+  changed_when: not pm2_automatic_start_status.stat.exists
+  notify: Configure pm2 automatic start at boot

--- a/ansible/roles/status-checker/templates/pm2-ecosystem.yml.j2
+++ b/ansible/roles/status-checker/templates/pm2-ecosystem.yml.j2
@@ -1,6 +1,6 @@
 apps:
   - script: webserver.py
-    name:  webserver
+    name: webserver
     cwd: "{{ webserver_directory }}"
     interpreter: /usr/bin/python3
     instances: 1

--- a/ansible/roles/status-checker/templates/pm2-ecosystem.yml.j2
+++ b/ansible/roles/status-checker/templates/pm2-ecosystem.yml.j2
@@ -1,0 +1,7 @@
+apps:
+  - script: webserver.py
+    name:  webserver
+    cwd: "{{ webserver_directory }}"
+    interpreter: /usr/bin/python3
+    instances: 1
+    exec_mode: fork

--- a/ansible/roles/status-checker/templates/webserver.py.j2
+++ b/ansible/roles/status-checker/templates/webserver.py.j2
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+import re
+import web
+import json
+import subprocess
+import os
+
+class Status:
+    def GET(self, args=None):
+        coturnStatus=0
+        readyToDelete=True
+        status=os.system("systemctl is-active --quiet " + "{{ service_name }}")
+        if status==0 :
+            coturnStatus=1
+            readyToDelete=False
+        return json.dumps({"serviceStatus":coturnStatus,"readyToDelete":readyToDelete})
+
+urls = ("/status", "Status")
+app = web.application(urls, globals())
+
+if __name__ == "__main__":
+    app.run()

--- a/ansible/roles/status-checker/templates/webserver.py.j2
+++ b/ansible/roles/status-checker/templates/webserver.py.j2
@@ -6,13 +6,13 @@ import os
 
 class Status:
     def GET(self, args=None):
-        serviceStatus=0
-        readyToDelete=True
-        status=os.system("systemctl is-active --quiet " + "{{ service_name }}")
-        if status==0 :
-            serviceStatus=1
-            readyToDelete=False
-        return json.dumps({"serviceStatus":serviceStatus,"readyToDelete":readyToDelete})
+        service_status = 0
+        ready_to_delete = True
+        status = os.system("systemctl is-active --quiet {{ service_name }}")
+        if status == 0:
+            service_status = 1
+            ready_to_delete = False
+        return json.dumps({ "serviceStatus": service_status, "readyToDelete": ready_to_delete })
 
 urls = ("/status", "Status")
 app = web.application(urls, globals())

--- a/ansible/roles/status-checker/templates/webserver.py.j2
+++ b/ansible/roles/status-checker/templates/webserver.py.j2
@@ -8,13 +8,13 @@ import os
 
 class Status:
     def GET(self, args=None):
-        coturnStatus=0
+        serviceStatus=0
         readyToDelete=True
         status=os.system("systemctl is-active --quiet " + "{{ service_name }}")
         if status==0 :
-            coturnStatus=1
+            serviceStatus=1
             readyToDelete=False
-        return json.dumps({"serviceStatus":coturnStatus,"readyToDelete":readyToDelete})
+        return json.dumps({"serviceStatus":serviceStatus,"readyToDelete":readyToDelete})
 
 urls = ("/status", "Status")
 app = web.application(urls, globals())

--- a/ansible/roles/status-checker/templates/webserver.py.j2
+++ b/ansible/roles/status-checker/templates/webserver.py.j2
@@ -1,9 +1,7 @@
 #!/usr/bin/python
 
-import re
 import web
 import json
-import subprocess
 import os
 
 class Status:

--- a/ansible/roles/status-checker/vars/main.yml
+++ b/ansible/roles/status-checker/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# Package versions
+webpy_package_version: 0.62
+pm2_package_version: 5.2.0


### PR DESCRIPTION
# Short description

It creates a new Ansible role to set up a web server that allows us to check the service status .

# Changes

Ansible role for the web server
Add the new role to the Kamailio and Coturn playbooks  

# Tests
These changes were tested on Kamailio and Coturn instances
