### PR TITLE
Fix Kamailio with TLS + FIP simultaneously

### DIFF
--- a/ansible/roles/kamailio/templates/kamailio.cfg.j2
+++ b/ansible/roles/kamailio/templates/kamailio.cfg.j2
@@ -114,7 +114,7 @@
 #!define WITH_DEBUG
 #!define WITH_NAT
 #!define WITH_JSONRPC
-{% if enable_tls %}#!define WITH_TLS{% endif %}
+{% if enable_tls %}#!define WITH_TLS{% endif +%}
 
 #!ifdef ACCDB_COMMENT
   ALTER TABLE acc ADD COLUMN src_user VARCHAR(64) NOT NULL DEFAULT '';
@@ -200,8 +200,8 @@ alias="{{ external_ip }}"
  * - basic prototype (full prototype can be found in Wiki - Core Cookbook):
  *      listen=[proto]:[localip]:[lport] advertise [publicip]:[pport]
  * - it can be set many times to add more sockets to listen to */
-listen=udp:{{ ansible_host }}:5060 advertise {{ external_ip }}:5060
 listen=tcp:{{ ansible_host }}:5060 advertise {{ external_ip }}:5060
+{% if enable_tls %}listen=tls:{{ ansible_host }}:5061 advertise {{ external_ip }}:5061{% endif +%}
 
 /* life time of TCP connection when there is no traffic
  * - a bit higher than registration expires to cope with UA behind NAT */

--- a/terraform/kamailio.cloud-init.sh
+++ b/terraform/kamailio.cloud-init.sh
@@ -5,15 +5,18 @@ KAMAILIO_EXTERNAL_IP=${kamailio_ip}
 KAMAILIO_DOMAIN=${kamailio_domain}
 SIP_SECRET=${sip_secret}
 
-# If the Kamailio domain is empty, rewrite it with the IP address
-[ -z "$KAMAILIO_DOMAIN" ] && KAMAILIO_DOMAIN=$KAMAILIO_EXTERNAL_IP
-
 sed -i -E "s/sipSrv=\"([0-9]{1,3}\.){3}[0-9]{1,3}\"/sipSrv=\"$KAMAILIO_EXTERNAL_IP\"/" /etc/kamailio/sipmediagw.cfg
 sed -i -E "s/sipSecret=\"[^\"]*\"/sipSecret=\"$SIP_SECRET\"/" /etc/kamailio/sipmediagw.cfg
 
-sed -i -E "s/alias=\"[^\"]*\"/alias=\"$KAMAILIO_DOMAIN\"/" /etc/kamailio/kamailio.cfg
-sed -i -E "s/^listen=udp:.*$/listen=udp:$KAMAILIO_INTERNAL_IP:5060 advertise $KAMAILIO_EXTERNAL_IP:5060/" /etc/kamailio/kamailio.cfg
+if [ -z "$KAMAILIO_DOMAIN" ]
+then
+    sed -i -E "s/alias=\"[^\"]*\"/alias=\"$KAMAILIO_EXTERNAL_IP\"/" /etc/kamailio/kamailio.cfg
+else
+    sed -i -E "s/alias=\"[^\"]*\"/alias=\"$KAMAILIO_EXTERNAL_IP\"\nalias=\"$KAMAILIO_DOMAIN\"/" /etc/kamailio/kamailio.cfg
+fi
+
 sed -i -E "s/^listen=tcp:.*$/listen=tcp:$KAMAILIO_INTERNAL_IP:5060 advertise $KAMAILIO_EXTERNAL_IP:5060/" /etc/kamailio/kamailio.cfg
+sed -i -E "s/^listen=tls:.*$/listen=tls:$KAMAILIO_INTERNAL_IP:5061 advertise $KAMAILIO_EXTERNAL_IP:5061/" /etc/kamailio/kamailio.cfg
 
 sed -i -E "s/SIP_DOMAIN=[^\"]*/SIP_DOMAIN=$KAMAILIO_EXTERNAL_IP/" /etc/kamailio/kamctlrc
 sed -i -E "s/DBACCESSHOST=[^\"]*/DBACCESSHOST=$KAMAILIO_INTERNAL_IP/" /etc/kamailio/kamctlrc


### PR DESCRIPTION
# Short description

It fixes a bug created by the simultaneous use of TLS, domain name for Kamailio and Floating IPs

# Changes

Added an additional alias for the domain name
Removed unused UDP socket
Added TLS socket

# Tests

Redeployed the whole stack